### PR TITLE
Fix bug on newer versions of Webpack Dev Server

### DIFF
--- a/lib/client/watchClientChanges.js
+++ b/lib/client/watchClientChanges.js
@@ -56,7 +56,8 @@ var watchClientChanges = function watchClientChanges(clientConfig) {
     headers: {
       'Access-Control-Allow-Origin': '*'
     },
-    hot: true
+    hot: true,
+    sockPort: port
   };
   var server = new _webpackDevServer["default"](compiler, devServerOptions);
   server.listen(port, 'localhost', function () {

--- a/src/client/watchClientChanges.js
+++ b/src/client/watchClientChanges.js
@@ -39,6 +39,7 @@ const watchClientChanges = clientConfig => {
       'Access-Control-Allow-Origin': '*',
     },
     hot: true,
+    sockPort: port,
   };
 
   const server = new webpackDevServer(compiler, devServerOptions);


### PR DESCRIPTION
webpack-dev-server version ~3.1.14 and upward need a `sockPort` parameter in order to function correctly.