### PR TITLE
watchClientChanges and watchServerChanges now return an HttpServer obj

### DIFF
--- a/src/client/watchClientChanges.js
+++ b/src/client/watchClientChanges.js
@@ -46,6 +46,7 @@ const watchClientChanges = clientConfig => {
   server.listen(port, 'localhost', () => {
     console.log(`Starting webpack-dev-server on ${webpackDevServerUrl}`);
   });
+  return server;
 };
 
 export default watchClientChanges;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@
 // TypeScript Version: 3.2.2
 
 import { Configuration } from 'webpack';
+import { Server } from 'net';
 
 /**
  * Gets the full webpack dev server url from the supplied client webpack config.
@@ -27,6 +28,11 @@ interface UniversalHotReloadConfig {
   serverConfig?: Configuration;
   clientConfig?: Configuration;
 }
+
+interface UniversalHotReloadHandles {
+  server?: Promise<Server>;
+  client?: Promise<Server>;
+}
 /**
  * Call this method with your webpack server and client configs in a ts file and run it to get
  * hot reload.
@@ -35,4 +41,4 @@ interface UniversalHotReloadConfig {
  * @param clientConfig - Your webpack config for the client
  */
 
-export default function universalHotReload({ serverConfig, clientConfig }: UniversalHotReloadConfig): void;
+export default function universalHotReload({ serverConfig, clientConfig }: UniversalHotReloadConfig): UniversalHotReloadHandles;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -41,4 +41,7 @@ interface UniversalHotReloadHandles {
  * @param clientConfig - Your webpack config for the client
  */
 
-export default function universalHotReload({ serverConfig, clientConfig }: UniversalHotReloadConfig): UniversalHotReloadHandles;
+export default function universalHotReload({
+  serverConfig,
+  clientConfig,
+}: UniversalHotReloadConfig): UniversalHotReloadHandles;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,7 +31,7 @@ interface UniversalHotReloadConfig {
 
 interface UniversalHotReloadHandles {
   server?: Promise<Server>;
-  client?: Promise<Server>;
+  client?: Server;
 }
 /**
  * Call this method with your webpack server and client configs in a ts file and run it to get

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import getDevServerUrl from './utils/getDevServerBundleUrl';
 export const getDevServerBundleUrl = getDevServerUrl;
 
 const main = ({ serverConfig, clientConfig }) => {
-  const handles = {}
+  const handles = {};
 
   if (clientConfig) {
     // Start webpack dev server separately on a different port to avoid issues with httpServer restarts
@@ -17,7 +17,7 @@ const main = ({ serverConfig, clientConfig }) => {
     handles.server = watchServerChanges(serverConfig);
   }
 
-  return handles
+  return handles;
 };
 
 export const serverHotReload = serverEntryPath => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,19 +5,23 @@ import getDevServerUrl from './utils/getDevServerBundleUrl';
 export const getDevServerBundleUrl = getDevServerUrl;
 
 const main = ({ serverConfig, clientConfig }) => {
+  const handles = {}
+
   if (clientConfig) {
     // Start webpack dev server separately on a different port to avoid issues with httpServer restarts
-    watchClientChanges(clientConfig);
+    handles.client = watchClientChanges(clientConfig);
   }
 
   if (serverConfig) {
     // Watch changes on the server side, re-compile and restart.
-    watchServerChanges(serverConfig);
+    handles.server = watchServerChanges(serverConfig);
   }
+
+  return handles
 };
 
 export const serverHotReload = serverEntryPath => {
-  watchServerChangesWithDefaultConfig(serverEntryPath);
+  return watchServerChangesWithDefaultConfig(serverEntryPath);
 };
 
 export default main;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -118,7 +118,7 @@ describe('index.js', () => {
       expect(returnValue).toBeTruthy();
       expect(returnValue.host).toEqual('localhost');
       expect(returnValue.port).toEqual('8001');
-    })
+    });
   });
 
   describe('server', () => {
@@ -133,13 +133,13 @@ describe('index.js', () => {
 
     describe('compiler', () => {
       beforeEach(() => {
-        watchServerChanges(serverConfig)
+        watchServerChanges(serverConfig);
       });
 
       test('compiler gets created', () => {
         expect(webpack.mock.calls[0][0]).toEqual(serverConfig);
       });
-  
+
       test('watch options are correct', () => {
         expect(mockServerCompiler.watch.mock.calls[0][0]).toEqual({
           aggregateTimeout: 300,
@@ -170,8 +170,8 @@ describe('index.js', () => {
         };
         initHttpServer.mockImplementation(() => mockServerInitObject);
         promiseHandler = jest.fn();
-        watchServerChanges(serverConfig).then((server) => {
-          promiseHandler(server)
+        watchServerChanges(serverConfig).then(server => {
+          promiseHandler(server);
         });
         [[, watchCallback]] = mockServerCompiler.watch.mock.calls;
       });
@@ -199,13 +199,13 @@ describe('index.js', () => {
         expect(mockSocket.destroy).toBeCalledTimes(1);
       });
 
-      test('the promise returned by watchServerChanges eventually resolves to a server', (done) => {
-        promiseHandler.mockImplementation((server) => {
-          expect(server).toBeTruthy()
-          expect(server.host).toEqual('localhost')
-          expect(server.port).toEqual('8001')
+      test('the promise returned by watchServerChanges eventually resolves to a server', done => {
+        promiseHandler.mockImplementation(server => {
+          expect(server).toBeTruthy();
+          expect(server.host).toEqual('localhost');
+          expect(server.port).toEqual('8001');
           done();
-        })
+        });
         watchCallback();
       });
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -47,6 +47,8 @@ describe('index.js', () => {
       };
       mockHmrPlugin = jest.fn();
       wdsMockInstance = {
+        host: 'localhost',
+        port: '8001',
         listen: jest.fn(),
       };
       webpack.mockImplementation(() => mockClientCompiler);
@@ -110,6 +112,13 @@ describe('index.js', () => {
       expect(listenCall[1]).toEqual('localhost');
       expect(typeof listenCall[2]).toEqual('function');
     });
+
+    test('watchClientChanges returns a server', () => {
+      const returnValue = watchClientChanges({ ...clientConfig });
+      expect(returnValue).toBeTruthy();
+      expect(returnValue.host).toEqual('localhost');
+      expect(returnValue.port).toEqual('8001');
+    })
   });
 
   describe('server', () => {
@@ -120,17 +129,22 @@ describe('index.js', () => {
         watch: jest.fn(),
       };
       webpack.mockImplementation(() => mockServerCompiler);
-      watchServerChanges(serverConfig);
     });
 
-    test('compiler gets created', () => {
-      expect(webpack.mock.calls[0][0]).toEqual(serverConfig);
-    });
+    describe('compiler', () => {
+      beforeEach(() => {
+        watchServerChanges(serverConfig)
+      });
 
-    test('watch options are correct', () => {
-      expect(mockServerCompiler.watch.mock.calls[0][0]).toEqual({
-        aggregateTimeout: 300,
-        poll: true,
+      test('compiler gets created', () => {
+        expect(webpack.mock.calls[0][0]).toEqual(serverConfig);
+      });
+  
+      test('watch options are correct', () => {
+        expect(mockServerCompiler.watch.mock.calls[0][0]).toEqual({
+          aggregateTimeout: 300,
+          poll: true,
+        });
       });
     });
 
@@ -138,14 +152,16 @@ describe('index.js', () => {
       let watchCallback;
       let mockServerInitObject;
       let mockSocket;
+      let promiseHandler;
 
       beforeEach(() => {
-        [[, watchCallback]] = mockServerCompiler.watch.mock.calls;
         mockSocket = {
           destroy: jest.fn(),
         };
         mockServerInitObject = {
           httpServer: {
+            host: 'localhost',
+            port: '8001',
             close: jest.fn(),
           },
           sockets: {
@@ -153,6 +169,11 @@ describe('index.js', () => {
           },
         };
         initHttpServer.mockImplementation(() => mockServerInitObject);
+        promiseHandler = jest.fn();
+        watchServerChanges(serverConfig).then((server) => {
+          promiseHandler(server)
+        });
+        [[, watchCallback]] = mockServerCompiler.watch.mock.calls;
       });
 
       test('watch callback logs errors', () => {
@@ -176,6 +197,16 @@ describe('index.js', () => {
         expect(initHttpServer).toBeCalledTimes(2);
         expect(mockServerInitObject.httpServer.close).toBeCalledTimes(1);
         expect(mockSocket.destroy).toBeCalledTimes(1);
+      });
+
+      test('the promise returned by watchServerChanges eventually resolves to a server', (done) => {
+        promiseHandler.mockImplementation((server) => {
+          expect(server).toBeTruthy()
+          expect(server.host).toEqual('localhost')
+          expect(server.port).toEqual('8001')
+          done();
+        })
+        watchCallback();
       });
     });
   });

--- a/src/server/watchServerChanges.js
+++ b/src/server/watchServerChanges.js
@@ -8,82 +8,87 @@ import generateDefaultConfig from './generateDefaultConfig';
  * Watches server for changes, recompile and restart express
  */
 const watchServerChanges = serverConfig => {
-  let initialLoad = true;
-  let httpServerInitObject; // contains the httpServer itself and socket references
-
-  const bundlePath = join(serverConfig.output.path, serverConfig.output.filename);
-  const serverCompiler = webpack(serverConfig);
-
-  // use this to debug
-  // const serverCompiler = webpack(serverConfig, (err, stats) => {
-  //   if (err || stats.hasErrors()) {
-  //     if (err) {
-  //       console.error(err.stack || err);
-  //       if (err.details) {
-  //         console.error(err.details);
-  //       }
-  //       return;
-  //     }
-  //     const info = stats.toJson();
-  //     if (stats.hasErrors()) {
-  //       console.error(info.errors);
-  //     }
-  //
-  //     if (stats.hasWarnings()) {
-  //       console.warn(info.warnings);
-  //     }
-  //   }
-  // });
-
-  const compilerOptions = {
-    aggregateTimeout: 300, // wait so long for more changes
-    poll: true, // use polling instead of native watchers
-  };
-
-  // compile server side code
-  serverCompiler.watch(compilerOptions, err => {
-    if (err) {
-      console.log(`Server bundling error: ${JSON.stringify(err)}`);
-      return;
-    }
-
-    clearRequireCache(bundlePath);
-
-    if (!initialLoad) {
-      httpServerInitObject.httpServer.close(() => {
+  return new Promise((resolve, reject) => {
+    let initialLoad = true;
+    let httpServerInitObject; // contains the httpServer itself and socket references
+  
+    const bundlePath = join(serverConfig.output.path, serverConfig.output.filename);
+    const serverCompiler = webpack(serverConfig);
+  
+    // use this to debug
+    // const serverCompiler = webpack(serverConfig, (err, stats) => {
+    //   if (err || stats.hasErrors()) {
+    //     if (err) {
+    //       console.error(err.stack || err);
+    //       if (err.details) {
+    //         console.error(err.details);
+    //       }
+    //       return;
+    //     }
+    //     const info = stats.toJson();
+    //     if (stats.hasErrors()) {
+    //       console.error(info.errors);
+    //     }
+    //
+    //     if (stats.hasWarnings()) {
+    //       console.warn(info.warnings);
+    //     }
+    //   }
+    // });
+  
+    const compilerOptions = {
+      aggregateTimeout: 300, // wait so long for more changes
+      poll: true, // use polling instead of native watchers
+    };
+  
+    // compile server side code
+    serverCompiler.watch(compilerOptions, err => {
+      if (err) {
+        console.log(`Server bundling error: ${JSON.stringify(err)}`);
+        reject(err)
+        return;
+      }
+  
+      clearRequireCache(bundlePath);
+  
+      if (!initialLoad) {
+        httpServerInitObject.httpServer.close(() => {
+          httpServerInitObject = initHttpServer(bundlePath);
+  
+          if (httpServerInitObject) {
+            initialLoad = false;
+            console.log(`Server bundled & restarted ${new Date()}`);
+            resolve(httpServerInitObject.httpServer);
+          } else {
+            // server bundling error has occurred
+            initialLoad = true;
+          }
+        });
+  
+        // Destroy all open sockets
+        // eslint-disable-next-line no-restricted-syntax
+        for (const socket of httpServerInitObject.sockets.values()) {
+          socket.destroy();
+        }
+      } else {
         httpServerInitObject = initHttpServer(bundlePath);
-
+  
         if (httpServerInitObject) {
           initialLoad = false;
-          console.log(`Server bundled & restarted ${new Date()}`);
+          console.log('Server bundled successfully');
+          resolve(httpServerInitObject.httpServer);
         } else {
           // server bundling error has occurred
           initialLoad = true;
         }
-      });
-
-      // Destroy all open sockets
-      // eslint-disable-next-line no-restricted-syntax
-      for (const socket of httpServerInitObject.sockets.values()) {
-        socket.destroy();
       }
-    } else {
-      httpServerInitObject = initHttpServer(bundlePath);
-
-      if (httpServerInitObject) {
-        initialLoad = false;
-        console.log('Server bundled successfully');
-      } else {
-        // server bundling error has occurred
-        initialLoad = true;
-      }
-    }
-  });
+    });
+  })
 };
 
 export const watchServerChangesWithDefaultConfig = serverEntryPath => {
   const defaultConfig = generateDefaultConfig(serverEntryPath);
-  watchServerChanges(defaultConfig);
+  return watchServerChanges(defaultConfig);
 };
 
 export default watchServerChanges;

--- a/src/server/watchServerChanges.js
+++ b/src/server/watchServerChanges.js
@@ -11,10 +11,10 @@ const watchServerChanges = serverConfig => {
   return new Promise((resolve, reject) => {
     let initialLoad = true;
     let httpServerInitObject; // contains the httpServer itself and socket references
-  
+
     const bundlePath = join(serverConfig.output.path, serverConfig.output.filename);
     const serverCompiler = webpack(serverConfig);
-  
+
     // use this to debug
     // const serverCompiler = webpack(serverConfig, (err, stats) => {
     //   if (err || stats.hasErrors()) {
@@ -35,26 +35,26 @@ const watchServerChanges = serverConfig => {
     //     }
     //   }
     // });
-  
+
     const compilerOptions = {
       aggregateTimeout: 300, // wait so long for more changes
       poll: true, // use polling instead of native watchers
     };
-  
+
     // compile server side code
     serverCompiler.watch(compilerOptions, err => {
       if (err) {
         console.log(`Server bundling error: ${JSON.stringify(err)}`);
-        reject(err)
+        reject(err);
         return;
       }
-  
+
       clearRequireCache(bundlePath);
-  
+
       if (!initialLoad) {
         httpServerInitObject.httpServer.close(() => {
           httpServerInitObject = initHttpServer(bundlePath);
-  
+
           if (httpServerInitObject) {
             initialLoad = false;
             console.log(`Server bundled & restarted ${new Date()}`);
@@ -64,7 +64,7 @@ const watchServerChanges = serverConfig => {
             initialLoad = true;
           }
         });
-  
+
         // Destroy all open sockets
         // eslint-disable-next-line no-restricted-syntax
         for (const socket of httpServerInitObject.sockets.values()) {
@@ -72,7 +72,7 @@ const watchServerChanges = serverConfig => {
         }
       } else {
         httpServerInitObject = initHttpServer(bundlePath);
-  
+
         if (httpServerInitObject) {
           initialLoad = false;
           console.log('Server bundled successfully');
@@ -83,7 +83,7 @@ const watchServerChanges = serverConfig => {
         }
       }
     });
-  })
+  });
 };
 
 export const watchServerChangesWithDefaultConfig = serverEntryPath => {


### PR DESCRIPTION
I'm using `universal-hot-reload` as part of a reusable build tool. I wanted to be able to:

* listen to the client and the server's lifecycle events
* show the client and the server's reported host and port
* run some basic health checks on each load or reload

So I figured the easiest way to do this was to have `universal-hot-reload` return the server objects themselves, so I could reference the servers in my own build tool. I hope this functionality is useful to others and doesn't interfere with existing workflows or planned features.