### PR TITLE
Fixing a race condition

### DIFF
--- a/src/client/watchClientChanges.js
+++ b/src/client/watchClientChanges.js
@@ -5,7 +5,7 @@ import webpackDevServer from 'webpack-dev-server';
 /**
  * Start webpack dev server for hmr
  */
-const watchClientChanges = clientConfig => {
+const watchClientChanges = (clientConfig, callback) => {
   const { publicPath } = clientConfig.output;
   const { protocol, host, port } = url.parse(publicPath);
   const webpackDevServerUrl = `${protocol}//${host}`;
@@ -41,6 +41,11 @@ const watchClientChanges = clientConfig => {
     hot: true,
     sockPort: port,
   };
+
+  // When the compiler is done, trigger the callback function
+  compiler.hooks.done.tap('watchClientChanges', () => {
+    if (callback) callback();
+  });
 
   const server = new webpackDevServer(compiler, devServerOptions);
   server.listen(port, 'localhost', () => {

--- a/src/client/watchClientChanges.js
+++ b/src/client/watchClientChanges.js
@@ -6,11 +6,13 @@ import webpackDevServer from 'webpack-dev-server';
  * Start webpack dev server for hmr
  */
 const watchClientChanges = (clientConfig, callback) => {
-  const { publicPath } = clientConfig.output;
+  const clonedClientConfig = { ...clientConfig };
+  const { entry, plugins, devServer = {} } = clonedClientConfig;
+
+  const { publicPath } = clonedClientConfig.output;
   const { protocol, host, port } = url.parse(publicPath);
   const webpackDevServerUrl = `${protocol}//${host}`;
 
-  const { entry, plugins } = clientConfig;
   const hmrEntries = [
     `${require.resolve('webpack-dev-server/client/')}?${webpackDevServerUrl}`,
     require.resolve('webpack/hot/dev-server'),
@@ -40,6 +42,7 @@ const watchClientChanges = (clientConfig, callback) => {
     },
     hot: true,
     sockPort: port,
+    ...devServer, // Add any overrides here
   };
 
   // When the compiler is done, trigger the callback function

--- a/src/index.js
+++ b/src/index.js
@@ -5,18 +5,29 @@ import getDevServerUrl from './utils/getDevServerBundleUrl';
 export const getDevServerBundleUrl = getDevServerUrl;
 
 const main = ({ serverConfig, clientConfig }) => {
-  if (clientConfig) {
+  // Universal app
+  if (clientConfig && serverConfig) {
     // Start webpack dev server separately on a different port to avoid issues with httpServer restarts
-    watchClientChanges(clientConfig);
+    // Requires that the client completely fully started the dev server before starting the server
+    watchClientChanges(clientConfig, () => {
+      // Once the client has fully started, watch changes on the server side, re-compile and restart.
+      watchServerChanges(serverConfig);
+    });
   }
 
-  if (serverConfig) {
-    // Watch changes on the server side, re-compile and restart.
-    watchServerChanges(serverConfig);
+  // Non-universal app
+  else {
+    if (clientConfig) {
+      // Start webpack dev server separately on a different port to avoid issues with httpServer restarts
+      watchClientChanges(clientConfig);
+    } else if (serverConfig) {
+      // Watch changes on the server side, re-compile and restart.
+      watchServerChanges(serverConfig);
+    }
   }
 };
 
-export const serverHotReload = serverEntryPath => {
+export const serverHotReload = (serverEntryPath) => {
   watchServerChangesWithDefaultConfig(serverEntryPath);
 };
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -44,6 +44,11 @@ describe('index.js', () => {
     beforeEach(() => {
       mockClientCompiler = {
         watch: jest.fn(),
+        hooks: {
+          done: {
+            tap: jest.fn(),
+          },
+        },
       };
       mockHmrPlugin = jest.fn();
       wdsMockInstance = {


### PR DESCRIPTION
There's a race condition that happens when the client does not finish compiling before the server watcher starts. The problem is that if the server requires files to exist that are part of the client compilation process, then there will be an error.

- [x] I've updated the mock implementation to be aware of the `done.tap()` hook on the Webpack `compiler` object. All tests are now passing.
- [x] I've tested this on my own codebase and it fixes the problem.
- [x] I've run the build command and confirmed it completes successfully.
- [x] I've made the callback optional as this functionality will only be necessary for a universal application

Let me know if you have any questions, but I think this should be good to merge as-is. It's a pretty simple change. 😄 